### PR TITLE
Make clean URL generation optional (default true)

### DIFF
--- a/lib/modules/build.js
+++ b/lib/modules/build.js
@@ -14,7 +14,7 @@ const build = (options = {}) => {
   log.info('Building site...');
   const startTime = process.hrtime();
 
-  const { srcPath, outputPath, site } = parseOptions(options);
+  const { srcPath, outputPath, cleanUrls, site } = parseOptions(options);
 
   // clear destination folder
   fse.emptyDirSync(outputPath);
@@ -27,7 +27,9 @@ const build = (options = {}) => {
   // read pages
   const files = glob.sync('**/*.@(md|ejs|html)', { cwd: `${srcPath}/pages` });
 
-  files.forEach(file => _buildPage(file, { srcPath, outputPath, site }));
+  files.forEach(file =>
+    _buildPage(file, { srcPath, outputPath, cleanUrls, site })
+  );
 
   // display build time
   const timeDiff = process.hrtime(startTime);
@@ -48,12 +50,12 @@ const _loadLayout = (layout, { srcPath }) => {
 /**
  * Build a single page
  */
-const _buildPage = (file, { srcPath, outputPath, site }) => {
+const _buildPage = (file, { srcPath, outputPath, cleanUrls, site }) => {
   const fileData = path.parse(file);
   let destPath = path.join(outputPath, fileData.dir);
 
-  // create extra dir if filename is not index
-  if (fileData.name !== 'index') {
+  // create extra dir if generating clean URLs and filename is not index
+  if (cleanUrls && fileData.name !== 'index') {
     destPath = path.join(destPath, fileData.name);
   }
 
@@ -102,7 +104,11 @@ const _buildPage = (file, { srcPath, outputPath, site }) => {
   );
 
   // save the html file
-  fse.writeFileSync(`${destPath}/index.html`, completePage);
+  if (cleanUrls) {
+    fse.writeFileSync(`${destPath}/index.html`, completePage);
+  } else {
+    fse.writeFileSync(`${destPath}/${fileData.name}.html`, completePage);
+  }
 };
 
 module.exports = build;

--- a/lib/utils/parser.js
+++ b/lib/utils/parser.js
@@ -1,17 +1,21 @@
-const buildDefaults = { srcPath: './src', outputPath: './public' };
+const buildDefaults = {
+  srcPath: './src',
+  outputPath: './public',
+  cleanUrls: true
+};
 
 /**
  * Parse options, setting the defaults on missing values
  */
 const parseOptions = options => {
-  const { srcPath, outputPath } = Object.assign(
+  const { srcPath, outputPath, cleanUrls } = Object.assign(
     {},
     buildDefaults,
     options.build
   );
   const site = options.site || {};
 
-  return { srcPath, outputPath, site };
+  return { srcPath, outputPath, cleanUrls, site };
 };
 
 module.exports = {


### PR DESCRIPTION
Current behaviour is to turn each page into a folder containing an index.html file, so `pages/about.md` turns into `about/index.html` for a nice clean extension-less URL of `/about/`. (As requested in #5)

Unfortunately, I'm looking to migrate an existing site that doesn't have those nice extension-less URLs, and I need to preserve the existing URLs by mapping directly from `pages/about.md` to `/about.html`.

This PR adds a new option to the site.config.js file in the `build` section: `cleanUrls` which defaults to true, preserving the existing behaviour of generating clean extension-less URLs.