### PR TITLE
Pass current relative URL into layouts

### DIFF
--- a/lib/modules/build.js
+++ b/lib/modules/build.js
@@ -53,10 +53,14 @@ const _loadLayout = (layout, { srcPath }) => {
 const _buildPage = (file, { srcPath, outputPath, cleanUrls, site }) => {
   const fileData = path.parse(file);
   let destPath = path.join(outputPath, fileData.dir);
+  let urlPath = path.posix.join(fileData.dir, '/');
 
   // create extra dir if generating clean URLs and filename is not index
   if (cleanUrls && fileData.name !== 'index') {
     destPath = path.join(destPath, fileData.name);
+    urlPath = path.posix.join(fileData.dir, fileData.name, '/');
+  } else if (!cleanUrls && fileData.name !== 'index') {
+    urlPath = path.posix.join(fileData.dir, `${fileData.name}.html`);
   }
 
   // create destination directory
@@ -69,7 +73,8 @@ const _buildPage = (file, { srcPath, outputPath, cleanUrls, site }) => {
   const pageData = frontMatter(data);
   const templateConfig = {
     site,
-    page: pageData.attributes
+    page: pageData.attributes,
+    path: urlPath
   };
 
   let pageContent;

--- a/test/mock/src/pages/with-url-path.ejs
+++ b/test/mock/src/pages/with-url-path.ejs
@@ -1,0 +1,1 @@
+relative URL: <%= path %>

--- a/test/modules/build.test.js
+++ b/test/modules/build.test.js
@@ -168,6 +168,32 @@ describe('build', function() {
     expect(page2).to.have.string('front-matter on page: test-ejs');
   });
 
+  it('should inject relative URL path', function() {
+    // when
+    nanogen.build(mockConfig);
+
+    // then
+    const page = fse.readFileSync(
+      `${mockConfig.build.outputPath}/with-url-path/index.html`,
+      'utf-8'
+    );
+    expect(page).to.have.string('relative URL: with-url-path/');
+  });
+
+  it('should inject relative URL path without clean URLs', function() {
+    // when
+    const config = Object.assign({}, mockConfig);
+    config.build = Object.assign({}, config.build, { cleanUrls: false });
+    nanogen.build(config);
+
+    // then
+    const page = fse.readFileSync(
+      `${mockConfig.build.outputPath}/with-url-path.html`,
+      'utf-8'
+    );
+    expect(page).to.have.string('relative URL: with-url-path.html');
+  });
+
   it('should include partial on layout', function() {
     // when
     nanogen.build(mockConfig);


### PR DESCRIPTION
This allows access to the relative URL for the currently rendering page. Combined with `site` data, this could be used to generate a canonical URL meta tag:

```ejs
<meta name="canonical" content="<%= site.domain + path %>">
```

### Example Outputs

Clean URLs | Source | `path` value
-----------------|-----------|----------------
true | index.md | /
true | articles/first-post.md | articles/first-post/
false | articles/first-post.md | articles/first-post.html