### PR TITLE
Create page.link and make available when generating page.

### DIFF
--- a/lib/modules/build.js
+++ b/lib/modules/build.js
@@ -54,10 +54,21 @@ const _buildPage = (file, { srcPath, outputPath, cleanUrls, site }) => {
   const fileData = path.parse(file);
   let destPath = path.join(outputPath, fileData.dir);
 
+  let outputFileName = fileData.name;
+  let pageLink = fileData.dir;
   // create extra dir if generating clean URLs and filename is not index
-  if (cleanUrls && fileData.name !== 'index') {
-    destPath = path.join(destPath, fileData.name);
+  if (outputFileName !== 'index') {
+    if (cleanUrls) {
+      destPath = path.join(destPath, outputFileName);
+      pageLink = path.join(pageLink, outputFileName);
+      outputFileName = 'index';
+    } else {
+      path.join(pageLink, `${outputFileName}.html`);
+    }
   }
+
+  // make sure the page link is websafe and not using windows backslashes
+  pageLink = pageLink.replace(/\\/g, "/");
 
   // create destination directory
   fse.mkdirsSync(destPath);
@@ -71,6 +82,11 @@ const _buildPage = (file, { srcPath, outputPath, cleanUrls, site }) => {
     site,
     page: pageData.attributes
   };
+
+  // if specific link not provided, use default one.
+  if (!templateConfig.page.link) {
+    templateConfig.page.link = pageLink;
+  }
 
   let pageContent;
   const pageSlug = file.split(path.sep).join('-');
@@ -104,11 +120,7 @@ const _buildPage = (file, { srcPath, outputPath, cleanUrls, site }) => {
   );
 
   // save the html file
-  if (cleanUrls) {
-    fse.writeFileSync(`${destPath}/index.html`, completePage);
-  } else {
-    fse.writeFileSync(`${destPath}/${fileData.name}.html`, completePage);
-  }
+  fse.writeFileSync(`${destPath}/${outputFileName}.html`, completePage);
 };
 
 module.exports = build;


### PR DESCRIPTION
Make available the path to the page, unless specifically specified. This allows for usage inside the the page itself (e.g. for canonical names)